### PR TITLE
Fix u64/UBigInt 'FromSql' trait impl

### DIFF
--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -81,6 +81,12 @@ macro_rules! from_sql_integral(
                     ValueRef::Int(i) => Ok(<$t as cast::From<i32>>::cast(i).unwrap()),
                     ValueRef::BigInt(i) => Ok(<$t as cast::From<i64>>::cast(i).unwrap()),
                     ValueRef::HugeInt(i) => Ok(<$t as cast::From<i128>>::cast(i).unwrap()),
+
+                    ValueRef::UTinyInt(i) => Ok(<$t as cast::From<u8>>::cast(i).unwrap()),
+                    ValueRef::USmallInt(i) => Ok(<$t as cast::From<u16>>::cast(i).unwrap()),
+                    ValueRef::UInt(i) => Ok(<$t as cast::From<u32>>::cast(i).unwrap()),
+                    ValueRef::UBigInt(i) => Ok(<$t as cast::From<u64>>::cast(i).unwrap()),
+
                     ValueRef::Float(i) => Ok(<$t as cast::From<f32>>::cast(i).unwrap()),
                     ValueRef::Double(i) => Ok(<$t as cast::From<f64>>::cast(i).unwrap()),
 


### PR DESCRIPTION
On line 157 of this file, we are invoking the macro:
```
from_sql_integral!(u64);
```
But the macro doesn't have an arm for ValueRef::UBigInt. 

The consequence is that, while inserting u64 into columns of type UBigInt succeeds, reading them back fails. 

I tested this simple fix locally within my project.