### PR TITLE
HugeInt write/readback failures

### DIFF
--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -313,6 +313,19 @@ mod test {
         Ok(())
     }
 
+    // This test asserts that i128s above/below the i64 max/min can written and retrieved properly.
+    #[test]
+    fn test_hugeint_max_min() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        db.execute("CREATE TABLE signed_int (u1 hugeint, u2 hugeint);", [])?;
+        let i128max: i128 = i128::MAX;
+        let i128min: i128 = i128::MIN;
+        db.execute("INSERT INTO signed_int VALUES (?, ?);", [&i128max, &i128min])?;
+        let v = db.query_row("SELECT * FROM signed_int", [], |row| <(i128, i128)>::try_from(row))?;
+        assert_eq!(v, (i128max, i128min));
+        Ok(())
+    }
+
     #[test]
     fn test_integral_ranges() -> Result<()> {
         let db = Connection::open_in_memory()?;


### PR DESCRIPTION
I noticed that, while writing hugeints, the value I read back from DB was not the same as the value I had written. This is true for all i128s which are larger than i64::MAX. 

I noticed that the Apache Arrow library being used under the hood does not have a DataType::Int128.
The function `value_ref` on `src/row.rs:342` does not have a match arm for handling i128 correctly. Somehow, the upper 64 bits of the HugeInt are definitely being thrown away by duckdb-rs conversions.

One option that should work well would be to use the `DataType::FixedSizeBinary` so that, from Arrow's perspective, you are passing around a 128-bit blob.

@wangfenjin , would you be able to help with making this test succeed? 😸 