### PR TITLE
Question about usage of RefCell and Connection being `!Sync`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ struct Person {
 }
 
 fn main() -> Result<()> {
-    let conn = Connection::open_in_memory()?;
+    let mut conn = Connection::open_in_memory()?;
 
     conn.execute_batch(
         r"CREATE SEQUENCE seq;

--- a/src/appender.rs
+++ b/src/appender.rs
@@ -22,7 +22,7 @@ impl Appender<'_> {
     ///
     /// ```rust,no_run
     /// # use duckdb::{Connection, Result, params};
-    /// fn insert_rows(conn: &Connection) -> Result<()> {
+    /// fn insert_rows(conn: &mut Connection) -> Result<()> {
     ///     let mut app = conn.appender("foo")?;
     ///     app.append_rows([[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]])?;
     ///     Ok(())
@@ -50,7 +50,7 @@ impl Appender<'_> {
     ///
     /// ```rust,no_run
     /// # use duckdb::{Connection, Result, params};
-    /// fn insert_row(conn: &Connection) -> Result<()> {
+    /// fn insert_row(conn: &mut Connection) -> Result<()> {
     ///     let mut app = conn.appender("foo")?;
     ///     app.append_row([1, 2])?;
     ///     Ok(())
@@ -156,7 +156,7 @@ mod test {
 
     #[test]
     fn test_append_one_row() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         db.execute_batch("CREATE TABLE foo(x INTEGER)")?;
 
         {
@@ -171,7 +171,7 @@ mod test {
 
     #[test]
     fn test_append_rows() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         db.execute_batch("CREATE TABLE foo(x INTEGER, y INTEGER)")?;
 
         {
@@ -191,7 +191,7 @@ mod test {
     fn test_append_uuid() -> Result<()> {
         use uuid::Uuid;
 
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         db.execute_batch("CREATE TABLE foo(x UUID)")?;
 
         let id = Uuid::new_v4();

--- a/src/appender_params.rs
+++ b/src/appender_params.rs
@@ -62,7 +62,7 @@ use sealed::Sealed;
 ///
 /// ```rust,no_run
 /// # use duckdb::{Connection, Result, params};
-/// fn update_rows(conn: &Connection) -> Result<()> {
+/// fn update_rows(conn: &mut Connection) -> Result<()> {
 ///     let mut stmt = conn.prepare("INSERT INTO test (a, b) VALUES (?, ?)")?;
 ///
 ///     // Using `duckdb::params!`:
@@ -96,7 +96,7 @@ use sealed::Sealed;
 ///
 /// ```rust,no_run
 /// # use duckdb::{Connection, Result, params};
-/// fn delete_all_users(conn: &Connection) -> Result<()> {
+/// fn delete_all_users(conn: &mut Connection) -> Result<()> {
 ///     // Just use an empty array (e.g. `[]`) for no params.
 ///     conn.execute("DELETE FROM users", [])?;
 ///     Ok(())
@@ -201,7 +201,7 @@ impl_for_array_ref!(
 /// use duckdb::{Connection, Result, params_from_iter};
 /// use std::collections::BTreeSet;
 ///
-/// fn query(conn: &Connection, ids: &BTreeSet<String>) -> Result<()> {
+/// fn query(conn: &mut Connection, ids: &BTreeSet<String>) -> Result<()> {
 ///     assert_eq!(ids.len(), 3, "Unrealistic sample code");
 ///
 ///     let mut stmt = conn.prepare("SELECT * FROM users WHERE id IN (?, ?, ?)")?;
@@ -220,7 +220,7 @@ impl_for_array_ref!(
 /// ```rust,no_run
 /// use duckdb::{Connection, Result};
 ///
-/// pub fn any_active_users(conn: &Connection, usernames: &[String]) -> Result<bool> {
+/// pub fn any_active_users(conn: &mut Connection, usernames: &[String]) -> Result<bool> {
 ///     if usernames.is_empty() {
 ///         return Ok(false);
 ///     }

--- a/src/column.rs
+++ b/src/column.rs
@@ -59,7 +59,7 @@ impl Statement<'_> {
     /// ```compile_fail
     /// use duckdb::{Connection, Result};
     /// fn main() -> Result<()> {
-    ///     let db = Connection::open_in_memory()?;
+    ///     let mut db = Connection::open_in_memory()?;
     ///     let mut stmt = db.prepare("SELECT 1 as x")?;
     ///     let column_name = stmt.column_name(0)?;
     ///     let x = stmt.query_row([], |r| r.get::<_, i64>(0))?; // E0502
@@ -148,7 +148,7 @@ mod test {
     fn test_columns() -> Result<()> {
         use super::Column;
 
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         let query = db.prepare("SELECT * FROM sqlite_master")?;
         let columns = query.columns();
         let column_names: Vec<&str> = columns.iter().map(Column::name).collect();
@@ -167,7 +167,7 @@ mod test {
     #[test]
     fn test_column_name_in_error() -> Result<()> {
         use crate::{types::Type, Error};
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         db.execute_batch(
             "BEGIN;
              CREATE TABLE foo(x INTEGER, y TEXT);

--- a/src/config.rs
+++ b/src/config.rs
@@ -140,7 +140,7 @@ mod test {
     #[test]
     fn test_default_config() -> Result<()> {
         let config = Config::default();
-        let db = Connection::open_in_memory_with_flags(config)?;
+        let mut db = Connection::open_in_memory_with_flags(config)?;
         db.execute_batch("CREATE TABLE foo(x Text)")?;
 
         let mut stmt = db.prepare("INSERT INTO foo(x) VALUES (?)")?;
@@ -174,7 +174,7 @@ mod test {
             .enable_object_cache(false)?
             .max_memory("2GB")?
             .threads(4)?;
-        let db = Connection::open_in_memory_with_flags(config)?;
+        let mut db = Connection::open_in_memory_with_flags(config)?;
         db.execute_batch("CREATE TABLE foo(x Text)")?;
 
         let mut stmt = db.prepare("INSERT INTO foo(x) VALUES (?)")?;

--- a/src/params.rs
+++ b/src/params.rs
@@ -62,7 +62,7 @@ use sealed::Sealed;
 ///
 /// ```rust,no_run
 /// # use duckdb::{Connection, Result, params};
-/// fn update_rows(conn: &Connection) -> Result<()> {
+/// fn update_rows(conn: &mut Connection) -> Result<()> {
 ///     let mut stmt = conn.prepare("INSERT INTO test (a, b) VALUES (?, ?)")?;
 ///
 ///     // Using `duckdb::params!`:
@@ -96,7 +96,7 @@ use sealed::Sealed;
 ///
 /// ```rust,no_run
 /// # use duckdb::{Connection, Result, params};
-/// fn delete_all_users(conn: &Connection) -> Result<()> {
+/// fn delete_all_users(conn: &mut Connection) -> Result<()> {
 ///     // Just use an empty array (e.g. `[]`) for no params.
 ///     conn.execute("DELETE FROM users", [])?;
 ///     Ok(())
@@ -201,7 +201,7 @@ impl_for_array_ref!(
 /// use duckdb::{Connection, Result, params_from_iter};
 /// use std::collections::BTreeSet;
 ///
-/// fn query(conn: &Connection, ids: &BTreeSet<String>) -> Result<()> {
+/// fn query(conn: &mut Connection, ids: &BTreeSet<String>) -> Result<()> {
 ///     assert_eq!(ids.len(), 3, "Unrealistic sample code");
 ///
 ///     let mut stmt = conn.prepare("SELECT * FROM users WHERE id IN (?, ?, ?)")?;
@@ -220,7 +220,7 @@ impl_for_array_ref!(
 /// ```rust,no_run
 /// use duckdb::{Connection, Result};
 ///
-/// pub fn any_active_users(conn: &Connection, usernames: &[String]) -> Result<bool> {
+/// pub fn any_active_users(conn: &mut Connection, usernames: &[String]) -> Result<bool> {
 ///     if usernames.is_empty() {
 ///         return Ok(false);
 ///     }

--- a/src/r2d2.rs
+++ b/src/r2d2.rs
@@ -28,7 +28,7 @@
 //!         .map(|i| {
 //!             let pool = pool.clone();
 //!             thread::spawn(move || {
-//!                 let conn = pool.get().unwrap();
+//!                 let mut conn = pool.get().unwrap();
 //!                 conn.execute("INSERT INTO foo (bar) VALUES (?)", &[&i])
 //!                     .unwrap();
 //!             })
@@ -204,7 +204,7 @@ mod test {
             .threads(4)?;
         let manager = DuckdbConnectionManager::file_with_flags(":memory:", config)?;
         let pool = r2d2::Pool::builder().max_size(2).build(manager).unwrap();
-        let conn = pool.get().unwrap();
+        let mut conn = pool.get().unwrap();
         conn.execute_batch("CREATE TABLE foo(x Text)")?;
 
         let mut stmt = conn.prepare("INSERT INTO foo(x) VALUES (?)")?;

--- a/src/row.rs
+++ b/src/row.rs
@@ -686,7 +686,7 @@ mod tests {
         use crate::ToSql;
         use std::convert::TryFrom;
 
-        let conn = Connection::open_in_memory()?;
+        let mut conn = Connection::open_in_memory()?;
         conn.execute(
             "CREATE TABLE test (a INTEGER)",
             crate::params_from_iter(std::iter::empty::<&dyn ToSql>()),
@@ -703,7 +703,7 @@ mod tests {
     fn test_try_from_row_for_tuple_2() -> Result<()> {
         use std::convert::TryFrom;
 
-        let conn = Connection::open_in_memory()?;
+        let mut conn = Connection::open_in_memory()?;
         conn.execute("CREATE TABLE test (a INTEGER, b INTEGER)", [])?;
         conn.execute("INSERT INTO test VALUES (42, 47)", [])?;
         let val = conn.query_row("SELECT a, b FROM test", [], |row| <(u32, u32)>::try_from(row))?;
@@ -774,7 +774,7 @@ mod tests {
             u32,
         );
 
-        let conn = Connection::open_in_memory()?;
+        let mut conn = Connection::open_in_memory()?;
         conn.execute(create_table, [])?;
         conn.execute(insert_values, [])?;
         let val = conn.query_row("SELECT * FROM test", [], |row| BigTuple::try_from(row))?;

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -30,7 +30,7 @@ impl Statement<'_> {
     ///
     /// ```rust,no_run
     /// # use duckdb::{Connection, Result, params};
-    /// fn update_rows(conn: &Connection) -> Result<()> {
+    /// fn update_rows(conn: &mut Connection) -> Result<()> {
     ///     let mut stmt = conn.prepare("UPDATE foo SET bar = 'baz' WHERE qux = ?")?;
     ///     // The `duckdb::params!` macro is mostly useful when the parameters do not
     ///     // all have the same type, or if there are more than 32 parameters
@@ -48,7 +48,7 @@ impl Statement<'_> {
     ///
     /// ```rust,no_run
     /// # use duckdb::{Connection, Result, params};
-    /// fn delete_all(conn: &Connection) -> Result<()> {
+    /// fn delete_all(conn: &mut Connection) -> Result<()> {
     ///     let mut stmt = conn.prepare("DELETE FROM users")?;
     ///     stmt.execute([])?;
     ///     Ok(())
@@ -96,7 +96,7 @@ impl Statement<'_> {
     /// ```rust,no_run
     /// # use duckdb::{Result, Connection};
     /// # use arrow::record_batch::RecordBatch;
-    /// fn get_arrow_data(conn: &Connection) -> Result<Vec<RecordBatch>> {
+    /// fn get_arrow_data(conn: &mut Connection) -> Result<Vec<RecordBatch>> {
     ///     Ok(conn.prepare("SELECT * FROM test")?.query_arrow([])?.collect())
     /// }
     /// ```
@@ -124,7 +124,7 @@ impl Statement<'_> {
     ///
     /// ```rust,no_run
     /// # use duckdb::{Connection, Result};
-    /// fn get_names(conn: &Connection) -> Result<Vec<String>> {
+    /// fn get_names(conn: &mut Connection) -> Result<Vec<String>> {
     ///     let mut stmt = conn.prepare("SELECT name FROM people")?;
     ///     let mut rows = stmt.query([])?;
     ///
@@ -141,7 +141,7 @@ impl Statement<'_> {
     ///
     /// ```rust,no_run
     /// # use duckdb::{Connection, Result};
-    /// fn query(conn: &Connection, name: &str) -> Result<()> {
+    /// fn query(conn: &mut Connection, name: &str) -> Result<()> {
     ///     let mut stmt = conn.prepare("SELECT * FROM test where name = ?")?;
     ///     let mut rows = stmt.query(duckdb::params![name])?;
     ///     while let Some(row) = rows.next()? {
@@ -155,7 +155,7 @@ impl Statement<'_> {
     ///
     /// ```rust,no_run
     /// # use duckdb::{Connection, Result};
-    /// fn query(conn: &Connection, name: &str) -> Result<()> {
+    /// fn query(conn: &mut Connection, name: &str) -> Result<()> {
     ///     let mut stmt = conn.prepare("SELECT * FROM test where name = ?")?;
     ///     let mut rows = stmt.query([name])?;
     ///     while let Some(row) = rows.next()? {
@@ -188,7 +188,7 @@ impl Statement<'_> {
     ///
     /// ```rust,no_run
     /// # use duckdb::{Connection, Result};
-    /// fn get_names(conn: &Connection) -> Result<Vec<String>> {
+    /// fn get_names(conn: &mut Connection) -> Result<Vec<String>> {
     ///     let mut stmt = conn.prepare("SELECT name FROM people")?;
     ///     let rows = stmt.query_map([], |row| row.get(0))?;
     ///
@@ -224,7 +224,7 @@ impl Statement<'_> {
     ///
     /// ```rust,no_run
     /// # use duckdb::{Connection, Result};
-    /// fn get_names(conn: &Connection) -> Result<Vec<String>> {
+    /// fn get_names(conn: &mut Connection) -> Result<Vec<String>> {
     ///     let mut stmt = conn.prepare("SELECT name FROM people WHERE id = ?")?;
     ///     let rows = stmt.query_and_then(["one"], |row| row.get::<_, String>(0))?;
     ///
@@ -348,7 +348,7 @@ impl Statement<'_> {
     ///
     /// ```rust,no_run
     /// # use duckdb::{Connection, Result};
-    /// fn query(conn: &Connection) -> Result<()> {
+    /// fn query(conn: &mut Connection) -> Result<()> {
     ///     let mut stmt = conn.prepare("SELECT * FROM test WHERE name = ? AND value > ?2")?;
     ///     stmt.raw_bind_parameter(1, "foo")?;
     ///     stmt.raw_bind_parameter(2, 100)?;
@@ -480,7 +480,7 @@ mod test {
 
     #[test]
     fn test_execute() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         db.execute_batch("CREATE TABLE foo(x INTEGER)")?;
 
         assert_eq!(db.execute("INSERT INTO foo(x) VALUES (?)", &[&2i32])?, 1);
@@ -500,7 +500,7 @@ mod test {
 
     #[test]
     fn test_stmt_execute() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         let sql = r#"
         CREATE SEQUENCE seq;
         CREATE TABLE test (id INTEGER DEFAULT NEXTVAL('seq'), name TEXT NOT NULL, flag INTEGER);
@@ -517,7 +517,7 @@ mod test {
 
     #[test]
     fn test_query() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         let sql = r#"
         CREATE TABLE test (id INTEGER PRIMARY KEY NOT NULL, name TEXT NOT NULL, flag INTEGER);
         INSERT INTO test(id, name) VALUES (1, 'one');
@@ -535,7 +535,7 @@ mod test {
 
     #[test]
     fn test_query_and_then() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         let sql = r#"
         CREATE TABLE test (id INTEGER PRIMARY KEY NOT NULL, name TEXT NOT NULL, flag INTEGER);
         INSERT INTO test(id, name) VALUES (1, 'one');
@@ -569,7 +569,7 @@ mod test {
 
     #[test]
     fn test_unbound_parameters_are_error() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         let sql = "CREATE TABLE test (x TEXT, y TEXT)";
         db.execute_batch(sql)?;
 
@@ -580,7 +580,7 @@ mod test {
 
     #[test]
     fn test_insert_empty_text_is_none() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         let sql = "CREATE TABLE test (x TEXT, y TEXT)";
         db.execute_batch(sql)?;
 
@@ -594,7 +594,7 @@ mod test {
 
     #[test]
     fn test_raw_binding() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         db.execute_batch("CREATE TABLE test (name TEXT, value INTEGER)")?;
         {
             let mut stmt = db.prepare("INSERT INTO test (name, value) VALUES (?, ?)")?;
@@ -625,7 +625,7 @@ mod test {
 
     #[test]
     fn test_insert_duplicate() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         db.execute_batch("CREATE TABLE foo(x INTEGER UNIQUE)")?;
         let mut stmt = db.prepare("INSERT INTO foo (x) VALUES (?)")?;
         // TODO(wangfenjin): currently always 1
@@ -643,7 +643,7 @@ mod test {
     #[test]
     fn test_insert_different_tables() -> Result<()> {
         // Test for https://github.com/duckdb/duckdb/issues/171
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         db.execute_batch(
             r"
             CREATE TABLE foo(x INTEGER);
@@ -658,7 +658,7 @@ mod test {
 
     #[test]
     fn test_exists() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         let sql = "BEGIN;
                    CREATE TABLE foo(x INTEGER);
                    INSERT INTO foo VALUES(1);
@@ -674,7 +674,7 @@ mod test {
 
     #[test]
     fn test_query_row() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         let sql = "BEGIN;
                    CREATE TABLE foo(x INTEGER, y INTEGER);
                    INSERT INTO foo VALUES(1, 3);
@@ -689,7 +689,7 @@ mod test {
 
     #[test]
     fn test_query_by_column_name() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         let sql = "BEGIN;
                    CREATE TABLE foo(x INTEGER, y INTEGER);
                    INSERT INTO foo VALUES(1, 3);
@@ -703,7 +703,7 @@ mod test {
 
     #[test]
     fn test_query_by_column_name_ignore_case() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         let sql = "BEGIN;
                    CREATE TABLE foo(x INTEGER, y INTEGER);
                    INSERT INTO foo VALUES(1, 3);
@@ -718,7 +718,7 @@ mod test {
     #[test]
     #[ignore]
     fn test_bind_parameters() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         // dynamic slice:
         db.query_row(
             "SELECT ?1, ?2, ?3",
@@ -749,7 +749,7 @@ mod test {
 
     #[test]
     fn test_empty_stmt() -> Result<()> {
-        let conn = Connection::open_in_memory()?;
+        let mut conn = Connection::open_in_memory()?;
         let stmt = conn.prepare("");
         assert!(stmt.is_err());
 
@@ -758,14 +758,14 @@ mod test {
 
     #[test]
     fn test_comment_empty_stmt() -> Result<()> {
-        let conn = Connection::open_in_memory()?;
+        let mut conn = Connection::open_in_memory()?;
         assert!(conn.prepare("/*SELECT 1;*/").is_err());
         Ok(())
     }
 
     #[test]
     fn test_comment_and_sql_stmt() -> Result<()> {
-        let conn = Connection::open_in_memory()?;
+        let mut conn = Connection::open_in_memory()?;
         let mut stmt = conn.prepare("/*...*/ SELECT 1;")?;
         stmt.execute([])?;
         assert_eq!(1, stmt.column_count());
@@ -775,7 +775,7 @@ mod test {
     #[test]
     #[ignore]
     fn test_utf16_conversion() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         db.pragma_update(None, "encoding", &"UTF-16le")?;
         let encoding: String = db.pragma_query_value(None, "encoding", |row| row.get(0))?;
         assert_eq!("UTF-16le", encoding);
@@ -790,7 +790,7 @@ mod test {
     #[test]
     #[ignore]
     fn test_nul_byte() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         let expected = "a\x00b";
         let actual: String = db.query_row("SELECT CAST(? AS VARCHAR)", [expected], |row| row.get(0))?;
         assert_eq!(expected, actual);

--- a/src/types/chrono.rs
+++ b/src/types/chrono.rs
@@ -131,14 +131,14 @@ mod test {
     use chrono::{DateTime, Duration, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 
     fn checked_memory_handle() -> Result<Connection> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         db.execute_batch("CREATE TABLE foo (d DATE, t Text, i INTEGER, f FLOAT, b TIMESTAMP, tt time)")?;
         Ok(db)
     }
 
     #[test]
     fn test_naive_time() -> Result<()> {
-        let db = checked_memory_handle()?;
+        let mut db = checked_memory_handle()?;
         let time = NaiveTime::from_hms_micro(23, 56, 4, 12_345);
         db.execute("INSERT INTO foo (tt) VALUES (?)", [time])?;
 
@@ -151,7 +151,7 @@ mod test {
 
     #[test]
     fn test_naive_date() -> Result<()> {
-        let db = checked_memory_handle()?;
+        let mut db = checked_memory_handle()?;
         let date = NaiveDate::from_ymd(2016, 2, 23);
         db.execute("INSERT INTO foo (d) VALUES (?)", [date])?;
 
@@ -164,7 +164,7 @@ mod test {
 
     #[test]
     fn test_naive_date_time() -> Result<()> {
-        let db = checked_memory_handle()?;
+        let mut db = checked_memory_handle()?;
         let date = NaiveDate::from_ymd(2016, 2, 23);
         let time = NaiveTime::from_hms(23, 56, 4);
         let dt = NaiveDateTime::new(date, time);
@@ -187,7 +187,7 @@ mod test {
 
     #[test]
     fn test_date_time_utc() -> Result<()> {
-        let db = checked_memory_handle()?;
+        let mut db = checked_memory_handle()?;
         let date = NaiveDate::from_ymd(2016, 2, 23);
         let time = NaiveTime::from_hms_milli(23, 56, 4, 789);
         let dt = NaiveDateTime::new(date, time);
@@ -214,7 +214,7 @@ mod test {
 
     #[test]
     fn test_date_time_local() -> Result<()> {
-        let db = checked_memory_handle()?;
+        let mut db = checked_memory_handle()?;
         let date = NaiveDate::from_ymd(2016, 2, 23);
         let time = NaiveTime::from_hms_milli(23, 56, 4, 789);
         let dt = NaiveDateTime::new(date, time);
@@ -232,7 +232,7 @@ mod test {
 
     #[test]
     fn test_duckdb_datetime_functions() -> Result<()> {
-        let db = checked_memory_handle()?;
+        let mut db = checked_memory_handle()?;
         let result: Result<NaiveDate> = db.query_row("SELECT CURRENT_DATE", [], |r| r.get(0));
         assert!(result.is_ok());
         let result: Result<NaiveDateTime> = db.query_row("SELECT CURRENT_TIMESTAMP", [], |r| r.get(0));
@@ -246,7 +246,7 @@ mod test {
 
     #[test]
     fn test_naive_date_time_param() -> Result<()> {
-        let db = checked_memory_handle()?;
+        let mut db = checked_memory_handle()?;
         let result: Result<bool> = db.query_row(
             "SELECT 1 WHERE ? BETWEEN (now() - INTERVAL '1 minute') AND (now() + INTERVAL '1 minute')",
             [Utc::now().naive_utc()],
@@ -258,7 +258,7 @@ mod test {
 
     #[test]
     fn test_date_time_param() -> Result<()> {
-        let db = checked_memory_handle()?;
+        let mut db = checked_memory_handle()?;
         // TODO(wangfenjin): why need 2 params?
         let result: Result<bool> = db.query_row(
             "SELECT 1 WHERE ? BETWEEN (now() - INTERVAL '1 minute') AND (now() + INTERVAL '1 minute')",

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -263,7 +263,7 @@ mod test {
 
     #[test]
     fn test_timestamp_raw() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         let sql = "BEGIN;
                    CREATE TABLE timestamp (sec TIMESTAMP_S, milli TIMESTAMP_MS, micro TIMESTAMP_US, nano TIMESTAMP_NS );
                    INSERT INTO timestamp VALUES (NULL,NULL,NULL,NULL );
@@ -282,7 +282,7 @@ mod test {
 
     #[test]
     fn test_time64_raw() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         let sql = "BEGIN;
                    CREATE TABLE time64 (t time);
                    INSERT INTO time64 VALUES ('20:08:10.998');
@@ -295,7 +295,7 @@ mod test {
 
     #[test]
     fn test_date32_raw() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         let sql = "BEGIN;
                    CREATE TABLE date32 (d date);
                    INSERT INTO date32 VALUES ('2008-01-01');
@@ -308,7 +308,7 @@ mod test {
 
     #[test]
     fn test_unsigned_integer() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         let sql = "BEGIN;
                    CREATE TABLE unsigned_int (u1 utinyint, u2 usmallint, u4 uinteger, u8 ubigint);
                    INSERT INTO unsigned_int VALUES (255, 65535, 4294967295, 18446744073709551615);
@@ -324,7 +324,7 @@ mod test {
     // This test asserts that i128s above/below the i64 max/min can written and retrieved properly.
     #[test]
     fn test_hugeint_max_min() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         db.execute("CREATE TABLE huge_int (u1 hugeint, u2 hugeint);", [])?;
         // Min/Max value defined in here: https://duckdb.org/docs/sql/data_types/numeric
         let i128max: i128 = i128::MAX;
@@ -337,9 +337,9 @@ mod test {
 
     #[test]
     fn test_integral_ranges() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
 
-        fn check_ranges<T>(db: &Connection, out_of_range: &[i128], in_range: &[i128])
+        fn check_ranges<T>(db: &mut Connection, out_of_range: &[i128], in_range: &[i128])
         where
             T: Into<i128> + FromSql + ::std::fmt::Debug,
         {
@@ -355,23 +355,23 @@ mod test {
             }
         }
 
-        check_ranges::<i8>(&db, &[-129, 128], &[-128, 0, 1, 127]);
-        check_ranges::<i16>(&db, &[-32769, 32768], &[-32768, -1, 0, 1, 32767]);
+        check_ranges::<i8>(&mut db, &[-129, 128], &[-128, 0, 1, 127]);
+        check_ranges::<i16>(&mut db, &[-32769, 32768], &[-32768, -1, 0, 1, 32767]);
         check_ranges::<i32>(
-            &db,
+            &mut db,
             &[-2_147_483_649, 2_147_483_648],
             &[-2_147_483_648, -1, 0, 1, 2_147_483_647],
         );
-        check_ranges::<u8>(&db, &[-2, -1, 256], &[0, 1, 255]);
-        check_ranges::<u16>(&db, &[-2, -1, 65536], &[0, 1, 65535]);
-        check_ranges::<u32>(&db, &[-2, -1, 4_294_967_296], &[0, 1, 4_294_967_295]);
+        check_ranges::<u8>(&mut db, &[-2, -1, 256], &[0, 1, 255]);
+        check_ranges::<u16>(&mut db, &[-2, -1, 65536], &[0, 1, 65535]);
+        check_ranges::<u32>(&mut db, &[-2, -1, 4_294_967_296], &[0, 1, 4_294_967_295]);
         Ok(())
     }
 
     // Don't need uuid crate if we only care about the string value of uuid
     #[test]
     fn test_uuid_string() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         let sql = "BEGIN;
                    CREATE TABLE uuid (u uuid);
                    INSERT INTO uuid VALUES ('10203040-5060-7080-0102-030405060708'),(NULL),('47183823-2574-4bfd-b411-99ed177d3e43');
@@ -393,7 +393,7 @@ mod test {
     #[cfg(feature = "uuid")]
     #[test]
     fn test_uuid_from_string() -> crate::Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         let sql = "BEGIN;
                    CREATE TABLE uuid (u uuid);
                    INSERT INTO uuid VALUES ('10203040-5060-7080-0102-030405060708'),(NULL),('47183823-2574-4bfd-b411-99ed177d3e43');

--- a/src/types/serde_json.rs
+++ b/src/types/serde_json.rs
@@ -32,14 +32,14 @@ mod test {
     use crate::{Connection, Result};
 
     fn checked_memory_handle() -> Result<Connection> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         db.execute_batch("CREATE TABLE foo (t TEXT, b BLOB)")?;
         Ok(db)
     }
 
     #[test]
     fn test_json_value() -> Result<()> {
-        let db = checked_memory_handle()?;
+        let mut db = checked_memory_handle()?;
 
         let json = r#"{"foo": 13, "bar": "baz"}"#;
         let data: serde_json::Value = serde_json::from_str(json).unwrap();

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -302,7 +302,7 @@ mod test {
     fn test_uuid_gen() -> crate::Result<()> {
         use crate::Connection;
 
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         db.execute_batch("CREATE TABLE foo (id uuid NOT NULL);")?;
 
         db.execute("INSERT INTO foo (id) VALUES (gen_random_uuid())", [])?;
@@ -321,7 +321,7 @@ mod test {
         use crate::{params, Connection};
         use uuid::Uuid;
 
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         db.execute_batch("CREATE TABLE foo (id BLOB CONSTRAINT uuidchk CHECK (octet_length(id) = 16), label TEXT);")?;
 
         let id = Uuid::new_v4();
@@ -344,7 +344,7 @@ mod test {
         use crate::{params, Connection};
         use uuid::Uuid;
 
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         db.execute_batch("CREATE TABLE foo (id uuid, label TEXT);")?;
 
         let id = Uuid::new_v4();


### PR DESCRIPTION
Hello!

You can ignore the actual diff of this PR for the moment, my real purpose is to raise a discussion.

1. I'm interested in wrapping `Connection` with an `Arc<RwLock<_>>` rather than an `Arc<Mutex<_>>`, so that I may have multiple reader threads simultaneously reading a database. (According to my reading of [1], [2], it's even alright for different **processes** to simultaneously read the same file, but I just want multiple async threads in the same process using the same connection. It doesn't seem like there would be any problem with this from DuckDB's perspective - Though I raised a thread on their discord channel to confirm this).

2. I noticed that `conn.execute_batch` takes a `&self` - immutable ref instead of mutable ref - which seemed odd to me, since it does mutate the underlying data. I realized this is possible due to the usage of RefCell and `borrow_mut` around `InnerConnection` which this crate took from rusqlite which was our starting point. This led me to a rusqlite thread where they discuss intentionally opting out of the compile-time borrow checker [3]. 

I realize that there are limitations of using the compile-time borrow checker... there's clearly not a practical/efficient way to check whether a raw SQL string is read-only or not... but the usage of RefCell makes our `Connection` struct `!Sync`. This means that I cannot pass `Arc<RwLock<Connection>>` into a `tokio::spawn_blocking` because only Mutex is the only wrapper that can make a non-`Sync` T into `Sync`.

So basically, my question is: do you think it's possible and/or desirable to make `Connection` into a `Sync` struct by avoiding usage of RefCell?
If I were to embark on that, do you think I should take special care to continue supporting the sqlite API's reference mutability?

The long term goal would be to make `query_arrow` take a immutable ref instead of a mut ref so that multiple Tokio threads can process SELECT statements on the same connection.

[1]: https://github.com/duckdb/duckdb/issues/1343
[2]: https://github.com/duckdb/duckdb/issues/77
[3]: https://github.com/rusqlite/rusqlite/pull/693
