### PR TITLE
Remove panic from inner connection initialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -933,12 +933,14 @@ mod test {
             owned_con.close().unwrap();
         }
 
-        // 2. Drop the original connection first. The cloned connection should still be able to run queries.
+        // 2. Close the original connection first. The cloned connection should still be able to run queries.
         {
             let cloned_con = {
                 let owned_con = checked_memory_handle();
+                let clone = owned_con.try_clone().unwrap();
                 owned_con.execute_batch("create table test (c1 bigint)")?;
-                owned_con.try_clone().unwrap()
+                owned_con.close().unwrap();
+                clone
             };
             cloned_con.execute_batch("create table test2 (c1 bigint)")?;
             cloned_con.close().unwrap();

--- a/src/r2d2.rs
+++ b/src/r2d2.rs
@@ -86,7 +86,7 @@ impl r2d2::ManageConnection for DuckdbConnectionManager {
 
     fn connect(&self) -> Result<Self::Connection, Self::Error> {
         let conn = self.connection.lock().unwrap();
-        Ok(conn.clone())
+        conn.try_clone()
     }
 
     fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {


### PR DESCRIPTION
It seems the main reason a `panic!` remains in `InnerConnection::new` was because the function signature is copied from rusqlite. In their case, this function was actually infallible. 

It's dangerous to leave this `panic!` in the code here - I have a hunch it was responsible for my host process crashing in https://github.com/duckdb/duckdb/issues/3666, probably due to attempting to connect to a corrupted database file.

If we have to choose between keeping their function signature or making this code safer, we ought to choose to make our code safer. 

The unfortunate side affect is that we can't impl `Clone` anymore for connection because creating a new connection is now fallible (Or rather, it already was fallible, but the use of `panic!` hid this from the type checker).