### PR TITLE
Compile from source on Windows

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          #- { target: x86_64-pc-windows-msvc, os: windows-latest }
+          - { target: x86_64-pc-windows-msvc, os: windows-latest }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
           #- { target: x86_64-apple-darwin, os: macos-latest }
           #- {

--- a/libduckdb-sys/build.rs
+++ b/libduckdb-sys/build.rs
@@ -65,7 +65,6 @@ mod build_bundled {
             .cpp(true)
             // .static_flag(true)
             .shared_flag(true)
-            .pic(true)
             .flag_if_supported("-std=c++11")
             .flag_if_supported("-stdlib=libc++")
             .flag_if_supported("-stdlib=libstdc++")

--- a/libduckdb-sys/build.rs
+++ b/libduckdb-sys/build.rs
@@ -69,6 +69,13 @@ mod build_bundled {
             .flag_if_supported("-stdlib=libc++")
             .flag_if_supported("-stdlib=libstdc++")
             .warnings(false);
+
+        let compiler = cfg.get_compiler();
+
+        if compiler.is_like_msvc() {
+            cfg.flag("/bigobj");
+        }
+
         cfg.compile(lib_name);
 
         println!("cargo:lib_dir={}", out_dir);

--- a/libduckdb-sys/build.rs
+++ b/libduckdb-sys/build.rs
@@ -38,6 +38,8 @@ fn main() {
 mod build_bundled {
     use std::path::Path;
 
+    use crate::win_target;
+
     pub fn main(out_dir: &str, out_path: &Path) {
         let lib_name = super::lib_name();
 
@@ -63,17 +65,14 @@ mod build_bundled {
         let mut cfg = cc::Build::new();
         cfg.file(format!("{}/duckdb.cpp", lib_name))
             .cpp(true)
-            // .static_flag(true)
-            .shared_flag(true)
             .flag_if_supported("-std=c++11")
             .flag_if_supported("-stdlib=libc++")
             .flag_if_supported("-stdlib=libstdc++")
+            .flag_if_supported("/bigobj")
             .warnings(false);
 
-        let compiler = cfg.get_compiler();
-
-        if compiler.is_like_msvc() {
-            cfg.flag("/bigobj");
+        if win_target() {
+            cfg.define("DUCKDB_BUILD_LIBRARY", None);
         }
 
         cfg.compile(lib_name);

--- a/libduckdb-sys/src/error.rs
+++ b/libduckdb-sys/src/error.rs
@@ -1,6 +1,6 @@
+use crate::duckdb_state;
 use std::error;
 use std::fmt;
-use std::os::raw::c_uint;
 
 /// Error Codes
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -59,11 +59,11 @@ pub enum ErrorCode {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Error {
     pub code: ErrorCode,
-    pub extended_code: c_uint,
+    pub extended_code: duckdb_state,
 }
 
 impl Error {
-    pub fn new(result_code: c_uint) -> Error {
+    pub fn new(result_code: duckdb_state) -> Error {
         Error {
             code: ErrorCode::Unknown,
             extended_code: result_code,
@@ -88,6 +88,6 @@ impl error::Error for Error {
     }
 }
 
-pub fn code_to_str(_: c_uint) -> &'static str {
+pub fn code_to_str(_: duckdb_state) -> &'static str {
     "Unknown error code"
 }

--- a/libduckdb-sys/src/lib.rs
+++ b/libduckdb-sys/src/lib.rs
@@ -13,8 +13,8 @@ pub use bindings::*;
 
 use std::os::raw::c_uint;
 
-pub const DuckDBError: c_uint = duckdb_state_DuckDBError;
-pub const DuckDBSuccess: c_uint = duckdb_state_DuckDBSuccess;
+pub const DuckDBError: c_uint = duckdb_state_DuckDBError as c_uint;
+pub const DuckDBSuccess: c_uint = duckdb_state_DuckDBSuccess as c_uint;
 
 pub use self::error::*;
 mod error;

--- a/libduckdb-sys/src/lib.rs
+++ b/libduckdb-sys/src/lib.rs
@@ -11,10 +11,8 @@ mod bindings {
 #[allow(clippy::all)]
 pub use bindings::*;
 
-use std::os::raw::c_uint;
-
-pub const DuckDBError: c_uint = duckdb_state_DuckDBError as c_uint;
-pub const DuckDBSuccess: c_uint = duckdb_state_DuckDBSuccess as c_uint;
+pub const DuckDBError: duckdb_state = duckdb_state_DuckDBError;
+pub const DuckDBSuccess: duckdb_state = duckdb_state_DuckDBSuccess;
 
 pub use self::error::*;
 mod error;

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,7 +116,7 @@ impl Config {
         };
         if state != ffi::DuckDBSuccess {
             return Err(Error::DuckDBFailure(
-                ffi::Error::new(state as u32),
+                ffi::Error::new(state),
                 Some(format!("set {}:{} error", key, value)),
             ));
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,6 @@ use crate::types::Type;
 use std::error;
 use std::ffi::CStr;
 use std::fmt;
-use std::os::raw::c_uint;
 use std::path::PathBuf;
 use std::str;
 
@@ -216,13 +215,13 @@ impl error::Error for Error {
 // These are public but not re-exported by lib.rs, so only visible within crate.
 
 #[inline]
-fn error_from_duckdb_code(code: c_uint, message: Option<String>) -> Result<()> {
-    Err(Error::DuckDBFailure(ffi::Error::new(code as u32), message))
+fn error_from_duckdb_code(code: ffi::duckdb_state, message: Option<String>) -> Result<()> {
+    Err(Error::DuckDBFailure(ffi::Error::new(code), message))
 }
 
 #[cold]
 #[inline]
-pub fn result_from_duckdb_appender(code: c_uint, mut appender: ffi::duckdb_appender) -> Result<()> {
+pub fn result_from_duckdb_appender(code: ffi::duckdb_state, mut appender: ffi::duckdb_appender) -> Result<()> {
     if code == ffi::DuckDBSuccess {
         return Ok(());
     }
@@ -241,7 +240,7 @@ pub fn result_from_duckdb_appender(code: c_uint, mut appender: ffi::duckdb_appen
 
 #[cold]
 #[inline]
-pub fn result_from_duckdb_prepare(code: c_uint, mut prepare: ffi::duckdb_prepared_statement) -> Result<()> {
+pub fn result_from_duckdb_prepare(code: ffi::duckdb_state, mut prepare: ffi::duckdb_prepared_statement) -> Result<()> {
     if code == ffi::DuckDBSuccess {
         return Ok(());
     }
@@ -260,7 +259,7 @@ pub fn result_from_duckdb_prepare(code: c_uint, mut prepare: ffi::duckdb_prepare
 
 #[cold]
 #[inline]
-pub fn result_from_duckdb_arrow(code: c_uint, mut out: ffi::duckdb_arrow) -> Result<()> {
+pub fn result_from_duckdb_arrow(code: ffi::duckdb_state, mut out: ffi::duckdb_arrow) -> Result<()> {
     if code == ffi::DuckDBSuccess {
         return Ok(());
     }

--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -39,7 +39,7 @@ impl InnerConnection {
             if r != ffi::DuckDBSuccess {
                 let msg = Some(CStr::from_ptr(c_err).to_string_lossy().to_string());
                 ffi::duckdb_free(c_err as *mut c_void);
-                return Err(Error::DuckDBFailure(ffi::Error::new(r as u32), msg));
+                return Err(Error::DuckDBFailure(ffi::Error::new(r), msg));
             }
             InnerConnection::new(db, true)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 //!     for person in person_iter {
 //!         println!("Found person {:?}", person.unwrap());
 //!     }
-//!    
+//!
 //!     // query table by arrow
 //!     let rbs: Vec<RecordBatch> = stmt.query_arrow([])?.collect();
 //!     print_batches(&rbs);
@@ -558,6 +558,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(windows, ignore = "Windows doesn't allow concurrent writes to a file")]
     fn test_concurrent_transactions_busy_commit() -> Result<()> {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("transactions.db3");


### PR DESCRIPTION
We found that you can compile the `duckdb-rs` crate with its `bundled` feature on Windows if you use Clang as the compiler (i.e. set `CC=clang` and `CXX=clang++`). All we needed to do is let the `cc` crate decide whether to emit `-fPIC` instead of forcing it to always be enabled (the default is `false` for Windows, `true` for everything else).

Fixes #62.