### PR TITLE
Re-exports arrow dependency to minimise version maintenance for crate…

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,17 @@ forked from rusqlite as duckdb also tries to expose a sqlite3 compatible API.
 
 ```rust
 use duckdb::{params, Connection, Result};
-use arrow::record_batch::RecordBatch;
-use arrow::util::pretty::print_batches;
+
+// In your project, we need to keep the arrow version same as the version used in duckdb.
+// Refer to https://github.com/wangfenjin/duckdb-rs/issues/92
+// You can either:
+use duckdb::arrow::record_batch::RecordBatch;
+// Or in your Cargo.toml, use * as the version; features can be toggled according to your needs
+// arrow = { version = "*", default-features = false, features = ["prettyprint"] }
+// Then you can:
+// use arrow::record_batch::RecordBatch;
+
+use duckdb::arrow::util::pretty::print_batches;
 
 #[derive(Debug)]
 struct Person {

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -2,8 +2,8 @@
 
 extern crate duckdb;
 
-use arrow::record_batch::RecordBatch;
-use arrow::util::pretty::print_batches;
+use duckdb::arrow::record_batch::RecordBatch;
+use duckdb::arrow::util::pretty::print_batches;
 use duckdb::{params, Connection, Result};
 
 #[derive(Debug)]

--- a/examples/parquet.rs
+++ b/examples/parquet.rs
@@ -1,8 +1,7 @@
 extern crate duckdb;
+use duckdb::arrow::record_batch::RecordBatch;
+use duckdb::arrow::util::pretty::print_batches;
 use duckdb::{Connection, Result};
-
-use arrow::record_batch::RecordBatch;
-use arrow::util::pretty::print_batches;
 
 fn main() -> Result<()> {
     let db = Connection::open_in_memory()?;

--- a/src/arrow_batch.rs
+++ b/src/arrow_batch.rs
@@ -1,5 +1,5 @@
+use super::arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
 use super::Statement;
-use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
 
 /// An handle for the resulting RecordBatch of a query.
 #[must_use = "Arrow is lazy and will do nothing unless consumed"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@
 //!
 //! ```rust
 //! use duckdb::{params, Connection, Result};
-//! use arrow::record_batch::RecordBatch;
-//! use arrow::util::pretty::print_batches;
+//! use duckdb::arrow::record_batch::RecordBatch;
+//! use duckdb::arrow::util::pretty::print_batches;
 //!
 //! #[derive(Debug)]
 //! struct Person {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,9 @@ pub use crate::statement::Statement;
 pub use crate::transaction::{DropBehavior, Savepoint, Transaction, TransactionBehavior};
 pub use crate::types::ToSql;
 
+// re-export dependencies from arrow-rs to minimise version maintenance for crate users
+pub use arrow;
+
 #[macro_use]
 mod error;
 mod appender;


### PR DESCRIPTION
Hi,

I think this is all that is required to fix #92.

For my use case it would be ideal if you could add `parquet` as well but I understand if you are hesitant to add a dependency to the crate that you're not even using. However `arrow` and `parquet` are often used together so if you want to write the results of your DuckDB query out to a parquet file then you might well run into the same versin dependency problem if you don't have access to the same version of `arrow` and `parquet`.

