### PR TITLE
Remove `buildtime_bindgen` from `bundled` feature

### DIFF
--- a/libduckdb-sys/Cargo.toml
+++ b/libduckdb-sys/Cargo.toml
@@ -16,7 +16,7 @@ description = "Native bindings to the libduckdb library, C API"
 
 [features]
 default = ["vcpkg", "pkg-config"]
-bundled = ["cc", "buildtime_bindgen"]
+bundled = ["cc"]
 buildtime_bindgen = ["bindgen", "pkg-config", "vcpkg"]
 
 [dependencies]


### PR DESCRIPTION
The README mentioned that you get pregenerated bindings if the `bundled` feature is used:

> If you use the `bundled` features, you will get pregenerated bindings for the bundled version of DuckDB. If you want to run `bindgen` at buildtime to produce your own bindings, use the `buildtime_bindgen` Cargo feature.

However, 2a500478c2f194baf94d804f01a4a273d1f83bd1 added the `buildtime_bindgen` to the `bundled` feature. So this statement doesn't hold true anymore.

This PR removes `buildtime_bindgen` from the `bundled` feature again, just in case including it wasn't on purpose. Otherwise, I'd like to suggest a README update instead 😊.