### PR TITLE
Update submodule URL to use the "Smart HTTP" protocol instead of the "SSH" protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "libduckdb-sys/duckdb-sources"]
 	path = libduckdb-sys/duckdb-sources
-	url = git@github.com:duckdb/duckdb.git
+    url = git@github.com:duckdb/duckdb.git
+    update = none


### PR DESCRIPTION
Hello,

I wanted to propose a small update that changes the way we interact with the `libduckdb-sys/duckdb-sources` submodule.

Currently, we're using `git@github.com:duckdb/duckdb.git` as the URL, which requires the [SSH protocol](https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols#_the_ssh_protocol). The SSH protocol isn't available everywhere (e.g. due to firewalls) and/or may not be configured with a user with permissions at all.

Instead, we should swap to the "Smart HTTP" protocol, which works just as well for a public repository that we only ever need to read from (e.g. we don't push to it).

This unblocks me from building in CI where access is severely restricted.

Thanks!