### PR TITLE
Suppress warnings in bundled compilation

### DIFF
--- a/libduckdb-sys/build.rs
+++ b/libduckdb-sys/build.rs
@@ -148,7 +148,8 @@ mod build_bundled {
             .flag_if_supported("-stdlib=libc++")
             .flag_if_supported("-stdlib=libstdc++")
             .flag_if_supported("/bigobj")
-            .warnings(false);
+            .warnings(false)
+            .flag_if_supported("-w");
 
         if win_target() {
             cfg.define("DUCKDB_BUILD_LIBRARY", None);


### PR DESCRIPTION
Now that we include OpenSSL (with the `httpfs` flag), on Mac machines, you get a bunch of compile warnings. As a user of `libduckdb-sys`, these warnings aren't "your fault", so I think it's poor developer experience for them to bleed out of the library. This change simply suppresses these warnings.