### PR TITLE
feat: make record_batch_to_chunk public

### DIFF
--- a/src/vtab/arrow.rs
+++ b/src/vtab/arrow.rs
@@ -192,6 +192,13 @@ pub fn to_duckdb_logical_type(data_type: &DataType) -> Result<LogicalType, Box<d
     }
 }
 
+/// Converts a `RecordBatch` to a `DataChunk` in the DuckDB format.
+///
+/// # Arguments
+///
+/// * `batch` - A reference to the `RecordBatch` to be converted to a `DataChunk`.
+/// * `chunk` - A mutable reference to the `DataChunk` to store the converted data.
+/// ```
 pub fn record_batch_to_duckdb_data_chunk(
     batch: &RecordBatch,
     chunk: &mut DataChunk,

--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -13,6 +13,7 @@ mod vector;
 mod arrow;
 #[cfg(feature = "vtab-arrow")]
 pub use self::arrow::arrow_ffi_to_query_params;
+pub use self::arrow::record_batch_to_duckdb_data_chunk;
 #[cfg(feature = "vtab-excel")]
 mod excel;
 


### PR DESCRIPTION
I wonder if you might consider making this function public, or if not you could share a good way to take an arrow record batch and convert it into a DataChunk.

My use case is passing a data chunk from C++ to Rust, then I'd like to use this to copy an arrow record batch to the data chunk.