### PR TITLE
Add `arrow-ipc` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ extensions-full = ["httpfs", "json", "parquet", "vtab-full"]
 buildtime_bindgen = ["libduckdb-sys/buildtime_bindgen"]
 modern-full = ["chrono", "serde_json", "url", "r2d2", "uuid", "polars"]
 polars = ["dep:polars"]
+arrow-ipc = ["arrow/ipc"]
 
 [dependencies]
 # time = { version = "0.3.2", features = ["formatting", "parsing"], optional = true }


### PR DESCRIPTION
Thanks for maintaining this project! I have a need for the `ipc` feature from the `arrow` crate, so I added a new feature flag to optionally include it.

#### Description

The `arrow-ipc` feature flag allows optional access to the `ipc` feature from the `arrow` crate so that Arrow IPC functionality can be used directly from the re-exported `arrow` dependency.

